### PR TITLE
feat: use slim base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.9.0
+FROM node:22.9.0-slim
 
 RUN npm install -g release-it
 


### PR DESCRIPTION
Closes #10 

> ## What
> 
> Convert the base image to a slim one, e.g. https://hub.docker.com/layers/library/node/22.9.0-slim/images/sha256-8b2f3a3d49ebd85cd80a0af1b94b7fc2b30e29364475655df9001fb01ee991c4?context=explore
> 
> ## Why
> 
> Use-cases of these images could benefit from smaller resource requirements.
> 
> ## How
> 
> Update base Dockerfile FROM
> 