### PR TITLE
Revert "feat: use slim base image"

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.9.0-slim
+FROM node:22.9.0
 
 RUN npm install -g release-it
 


### PR DESCRIPTION
Revert using slim base image; packages (e.g. git) of the non-slim image are required for use of release-it