### PR TITLE
release-it tag protection settings

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -20,6 +20,10 @@ rulesets:
         include:
           - "~ALL"
         exclude: []
+    bypass_actors:
+      - actor_id: 1033419
+        actor_type: Integration
+        bypass_mode: always
     rules:
       - type: creation
       - type: deletion
@@ -34,7 +38,7 @@ rulesets:
           - "~DEFAULT_BRANCH"
         exclude: []
     bypass_actors:
-      - actor_id: 5
+      - actor_id: 5 # Based on https://registry.terraform.io/providers/integrations/github/latest/docs/resources/organization_ruleset#bypass_actors
         actor_type: RepositoryRole
         bypass_mode: pull_request
     rules:
@@ -55,7 +59,15 @@ rulesets:
           required_status_checks:
             - context: Build Docker images
               integration_id: 15368 # GitHub Actions integration ID
+            - context: Release-it workflow / Release-it dry-run
+              integration_id: 15368 # GitHub Actions integration ID
           # Requires PR branches to be up-to-date with target
           strict_required_status_checks_policy: true
 
 collaborators: [] # No collaborators defined
+
+environments:
+  - name: Repo release
+    deployment_branch_policy:
+      custom_branches:
+        - main


### PR DESCRIPTION
Relates to #5 

> ## What
> 
> Apply [release-it action](https://github.com/rcwbr/release-it-action) to workflow.
> 
> ## Why
> 
> Release of the image should be automated via CI/CD.
> 
> ## How
> 
> Add release-it actions to the workflow definition