### PR TITLE
define default release-it configs

### DIFF
--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -26,6 +26,8 @@ jobs:
           workdir: base
           source: https://github.com/rcwbr/dockerfile-partials.git#main
           files: github-cache-bake.hcl
+          set: |
+            default.context=cwd://
         env:
           REGISTRY: ghcr.io/rcwbr/
           IMAGE_NAME: release-it-docker
@@ -36,6 +38,8 @@ jobs:
           workdir: conventional-changelog
           source: https://github.com/rcwbr/dockerfile-partials.git#main
           files: github-cache-bake.hcl, cwd://docker-bake.hcl
+          set: |
+            default.context=cwd://
         env:
           REGISTRY: ghcr.io/rcwbr/
           IMAGE_NAME: release-it-docker-conventional-changelog

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ The conventional-changelog image includes the [conventional-changelog](https://g
 docker run -it ghcr.io/rcwbr/release-it-docker-conventional-changelog:0.1.0
 ```
 
+### Default configurations
+
+Both the base and conventional-changelog images provide a default [release-it configuration](https://github.com/release-it/release-it/blob/main/docs/configuration.md), located at `/.release-it.json`. To use this config, provide an arg to release-it:
+
+```bash
+docker run -it ghcr.io/rcwbr/release-it-docker:0.1.0 --config /.release-it.json
+```
+
 ## Contributing
 
 ### Build

--- a/base/.release-it.json
+++ b/base/.release-it.json
@@ -1,0 +1,8 @@
+{
+  "git": {
+    "commit": false
+  },
+  "github": {
+    "release": true
+  }
+}

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -2,4 +2,5 @@ FROM node:22.9.0
 
 RUN npm install -g release-it
 
+COPY .release-it.json /.release-it.json
 ENTRYPOINT [ "release-it" ]

--- a/conventional-changelog/.release-it.json
+++ b/conventional-changelog/.release-it.json
@@ -1,0 +1,59 @@
+{
+  "git": {
+    "commit": false,
+    "tag": true,
+    "tagName": "${version}"
+  },
+  "github": {
+    "release": true
+  },
+  "plugins": {
+    "@release-it/conventional-changelog": {
+      "preset": {
+        "name": "conventionalcommits",
+        "types": [
+          {
+            "type": "feat",
+            "section": ":rocket: Features"
+          },
+          {
+            "type": "fix",
+            "section": ":bug: Bug fixes"
+          },
+          {
+            "type": "build",
+            "section": ":package: Build"
+          },
+          {
+            "type": "ci",
+            "section": ":robot: CI/CD"
+          },
+          {
+            "type": "docs",
+            "section": ":page_facing_up: Docs"
+          },
+          {
+            "type": "perf",
+            "section": ":checkered_flag: Performance"
+          },
+          {
+            "type": "refactor",
+            "section": ":twisted_rightwards_arrows: Refactor"
+          },
+          {
+            "type": "style",
+            "section": ":broom: Style"
+          },
+          {
+            "type": "test",
+            "section": ":test_tube: Tests"
+          },
+          {
+            "type": "chore",
+            "hidden": true
+          }
+        ]
+      }
+    }
+  }
+}

--- a/conventional-changelog/Dockerfile
+++ b/conventional-changelog/Dockerfile
@@ -1,3 +1,4 @@
 FROM base
 
 RUN npm install -g @release-it/conventional-changelog
+COPY .release-it.json /.release-it.json


### PR DESCRIPTION
Closes #17 

> ## What
> 
> Define default release-it configurations
> 
> ## Why
> 
> Many use-cases will leverage similar configurations. Providing these as default saves duplication
> 
> ## How
> 
> Bake config files into image definitions