### PR TITLE
fix: avoid commit suffixes on release tags

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -21,7 +21,7 @@ rulesets:
           - "~ALL"
         exclude: []
     bypass_actors:
-      - actor_id: 1033419
+      - actor_id: 1033419 # release-it-docker-ci-release-it App ID
         actor_type: Integration
         bypass_mode: always
     rules:

--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -31,6 +31,7 @@ jobs:
         env:
           REGISTRY: ghcr.io/rcwbr/
           IMAGE_NAME: release-it-docker
+          GITHUB_REF_PROTECTED: ${{ github.ref_protected || github.ref_type == 'tag' }} # See https://github.com/orgs/community/discussions/142985
       -
         name: Docker Bake conventional-changelog
         uses: docker/bake-action@v5.7.0
@@ -43,6 +44,7 @@ jobs:
         env:
           REGISTRY: ghcr.io/rcwbr/
           IMAGE_NAME: release-it-docker-conventional-changelog
+          GITHUB_REF_PROTECTED: ${{ github.ref_protected || github.ref_type == 'tag' }} # See https://github.com/orgs/community/discussions/142985
   release-it-workflow:
     name: Release-it workflow
     # uses: rcwbr/release-it-gh-workflow/.github/workflows/release-it-workflow.yaml@0.1.0 TODO use released ref


### PR DESCRIPTION
Closes #36 

> ## What
> 
> Override GitHub-provided ref protected variable to correct the image ref format for tag workflows
> 
> ## Why
> 
> The provided variable is [never `true` for tags, even if protected](https://github.com/orgs/community/discussions/142985), resulting in image refs with commit SHAs (e.g. the [0.1.1 image](https://github.com/rcwbr/release-it-docker/actions/runs/11564269630/job/32189148379#step:6:314))
> 
> ## How
> 
> Override the `GITHUB_REF_PROTECTED` variable
> 