### PR TITLE
Convert release-it automation to use tagged workflow ref and self image ref

### DIFF
--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -20,6 +20,7 @@ jobs:
         name: Docker Buildx builder setup
         uses: docker/setup-buildx-action@v3.6.1
       -
+        id: docker-bake-base
         name: Docker Bake base
         uses: docker/bake-action@v5.7.0
         with:
@@ -31,8 +32,8 @@ jobs:
         env:
           REGISTRY: ghcr.io/rcwbr/
           IMAGE_NAME: release-it-docker
-          GITHUB_REF_PROTECTED: ${{ github.ref_protected || github.ref_type == 'tag' }} # See https://github.com/orgs/community/discussions/142985
       -
+        id: docker-bake-conventional-changelog
         name: Docker Bake conventional-changelog
         uses: docker/bake-action@v5.7.0
         with:
@@ -44,12 +45,15 @@ jobs:
         env:
           REGISTRY: ghcr.io/rcwbr/
           IMAGE_NAME: release-it-docker-conventional-changelog
-          GITHUB_REF_PROTECTED: ${{ github.ref_protected || github.ref_type == 'tag' }} # See https://github.com/orgs/community/discussions/142985
+    outputs:
+      docker-bake-base-metadata: ${{ steps.docker-bake-base.outputs.metadata }}
+      docker-bake-conventional-changelog-metadata: ${{ steps.docker-bake-conventional-changelog.outputs.metadata }}
   release-it-workflow:
     name: Release-it workflow
-    # uses: rcwbr/release-it-gh-workflow/.github/workflows/release-it-workflow.yaml@0.1.0 TODO use released ref
-    uses: rcwbr/release-it-gh-workflow/.github/workflows/release-it-workflow.yaml@1-define-initial-workflow
+    uses: rcwbr/release-it-gh-workflow/.github/workflows/release-it-workflow.yaml@0.1.0
+    needs: build-docker-images
     with:
+      release-it-image: ${{ fromJSON(needs.build-docker-images.outputs.docker-bake-conventional-changelog-metadata)['default']['image.name'] }}
       app-id: 1033419 # release-it-docker CI release-it app
       app-environment: Repo release
     secrets:

--- a/conventional-changelog/docker-bake.hcl
+++ b/conventional-changelog/docker-bake.hcl
@@ -4,7 +4,7 @@
 target "default" {
   contexts = {
     base = (
-      "${GITHUB_REF_PROTECTED}" == "true"
+      ("${GITHUB_REF_PROTECTED}" == "true" || "${GITHUB_REF_TYPE}" == "tag" )
       ? "docker-image://${REGISTRY}release-it-docker:${VERSION}"
       : "docker-image://${REGISTRY}release-it-docker:${VERSION}-${GITHUB_SHA}"
     )


### PR DESCRIPTION
Closes #6

> ## What
> 
> Change workflow definition to an immutable (tag) ref of the [reusable workflow](https://github.com/rcwbr/release-it-gh-workflow), and ensure that workflows use the image version they generate for self-release.
> 
> ## Why
> 
> Ensures changes to the workflow definition are tested within this project, and to enable the shipment of changes that need themselves to release
> 
> ## How
> 
> Leverage a released reference of the workflow and use a calculated image ref as an input