### PR TITLE
feat: lock dockerfile-partials ref to tag

### DIFF
--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: docker/bake-action@v5.7.0
         with:
           workdir: base
-          source: https://github.com/rcwbr/dockerfile-partials.git#main
+          source: https://github.com/rcwbr/dockerfile-partials.git#0.1.0
           files: github-cache-bake.hcl
           set: |
             default.context=cwd://
@@ -38,7 +38,7 @@ jobs:
         uses: docker/bake-action@v5.7.0
         with:
           workdir: conventional-changelog
-          source: https://github.com/rcwbr/dockerfile-partials.git#main
+          source: https://github.com/rcwbr/dockerfile-partials.git#0.1.0
           files: github-cache-bake.hcl, cwd://docker-bake.hcl
           set: |
             default.context=cwd://

--- a/conventional-changelog/docker-bake.hcl
+++ b/conventional-changelog/docker-bake.hcl
@@ -1,5 +1,5 @@
 // Expected to be used with https://github.com/rcwbr/dockerfile-partials/blob/main/github-cache-bake.hcl
-// For example, docker buildx bake -f github-cache-bake.hcl -f cwd://docker-bake.hcl https://github.com/rcwbr/dockerfile-partials.git#main
+// For example, docker buildx bake -f github-cache-bake.hcl -f cwd://docker-bake.hcl https://github.com/rcwbr/dockerfile-partials.git#0.1.0
 
 target "default" {
   contexts = {


### PR DESCRIPTION
Closes #7 

> ## What
> 
> Use a tag reference for the github-cache-bake.hcl version
> 
> ## Why
> 
> To establish an immutable reference, thus avoiding unexpected breaking changes
> 
> ## How
> 
> Adjust the reference from `main` to `0.1.0`