### PR TITLE
release-it required check

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -59,7 +59,7 @@ rulesets:
           required_status_checks:
             - context: Build Docker images
               integration_id: 15368 # GitHub Actions integration ID
-            - context: Release-it workflow / Release-it dry-run
+            - context: release-it-workflow / Release-it dry-run
               integration_id: 15368 # GitHub Actions integration ID
           # Requires PR branches to be up-to-date with target
           strict_required_status_checks_policy: true

--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -49,7 +49,6 @@ jobs:
       docker-bake-base-metadata: ${{ steps.docker-bake-base.outputs.metadata }}
       docker-bake-conventional-changelog-metadata: ${{ steps.docker-bake-conventional-changelog.outputs.metadata }}
   release-it-workflow:
-    name: Release-it workflow
     uses: rcwbr/release-it-gh-workflow/.github/workflows/release-it-workflow.yaml@0.1.0
     needs: build-docker-images
     with:


### PR DESCRIPTION
Closes #44 

> ## What
> 
> Fix the name of the required check for release-it in PRs
> 
> ## Why
> 
> The reported check from the workflow doesn't match the required check, resulting in all PRs being blocked
> 
> ## How
> 
> Adjust the `settings.yml` content for required checks