### PR TITLE
Manage inline version files

### DIFF
--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -45,9 +45,23 @@ jobs:
         env:
           REGISTRY: ghcr.io/rcwbr/
           IMAGE_NAME: release-it-docker-conventional-changelog
+      -
+        id: docker-bake-file-bumper
+        name: Docker Bake file-bumper
+        uses: docker/bake-action@v5.7.0
+        with:
+          workdir: file-bumper
+          source: https://github.com/rcwbr/dockerfile-partials.git#0.1.0
+          files: github-cache-bake.hcl, cwd://docker-bake.hcl
+          set: |
+            default.context=cwd://
+        env:
+          REGISTRY: ghcr.io/rcwbr/
+          IMAGE_NAME: release-it-docker-file-bumper
     outputs:
       docker-bake-base-metadata: ${{ steps.docker-bake-base.outputs.metadata }}
       docker-bake-conventional-changelog-metadata: ${{ steps.docker-bake-conventional-changelog.outputs.metadata }}
+      docker-bake-file-bumper-metadata: ${{ steps.docker-bake-file-bumper.outputs.metadata }}
   release-it-workflow:
     uses: rcwbr/release-it-gh-workflow/.github/workflows/release-it-workflow.yaml@0.1.0
     needs: build-docker-images

--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ The conventional-changelog image includes the [conventional-changelog](https://g
 docker run -it ghcr.io/rcwbr/release-it-docker-conventional-changelog:0.1.0
 ```
 
+### File bumper image usage
+
+The file-bumper image includes the [bumper release-it plugin](https://github.com/release-it/bumper). To use the image:
+
+```
+docker run -it ghcr.io/rcwbr/release-it-docker-file-bumper:0.1.0
+```
+
+If using the [default configuration](#default-configurations), it is configured to bump versions in a plaintext `VERSION` file. By default, it will replace the entire contents of the file with the version number.
+
+> :warning: Unlike the other images, the bumper release-it default configuration sets `git.commit` true (as the version file bump must be committed) and `git.pushArgs` to `["tags"]` so as to push the tag only and not commit to the default branch. It also configures `git.getLatestTagFromAllRefs` true so that the latest tag may still be discovered despite not being associated with a commit on the default branch.
+
 ### Default configurations
 
 Both the base and conventional-changelog images provide a default [release-it configuration](https://github.com/release-it/release-it/blob/main/docs/configuration.md), located at `/.release-it.json`. To use this config, provide an arg to release-it:

--- a/file-bumper/.release-it.json
+++ b/file-bumper/.release-it.json
@@ -1,0 +1,68 @@
+{
+  "git": {
+    "getLatestTagFromAllRefs": true,
+    "commit": true,
+    "tag": true,
+    "pushArgs": ["--tags"],
+    "tagName": "${version}"
+  },
+  "github": {
+    "release": true
+  },
+  "plugins": {
+    "@release-it/bumper": {
+      "out": {
+        "file": "VERSION",
+        "type": "text/plain",
+        "consumeWholeFile": true
+      }
+    },
+    "@release-it/conventional-changelog": {
+      "preset": {
+        "name": "conventionalcommits",
+        "types": [
+          {
+            "type": "feat",
+            "section": ":rocket: Features"
+          },
+          {
+            "type": "fix",
+            "section": ":bug: Bug fixes"
+          },
+          {
+            "type": "build",
+            "section": ":package: Build"
+          },
+          {
+            "type": "ci",
+            "section": ":robot: CI/CD"
+          },
+          {
+            "type": "docs",
+            "section": ":page_facing_up: Docs"
+          },
+          {
+            "type": "perf",
+            "section": ":checkered_flag: Performance"
+          },
+          {
+            "type": "refactor",
+            "section": ":twisted_rightwards_arrows: Refactor"
+          },
+          {
+            "type": "style",
+            "section": ":broom: Style"
+          },
+          {
+            "type": "test",
+            "section": ":test_tube: Tests"
+          },
+          {
+            "type": "chore",
+            "hidden": true
+          }
+        ]
+      }
+    }
+  }
+}

--- a/file-bumper/Dockerfile
+++ b/file-bumper/Dockerfile
@@ -1,0 +1,4 @@
+FROM base
+
+RUN npm install -g @release-it/bumper
+COPY .release-it.json /.release-it.json

--- a/file-bumper/docker-bake.hcl
+++ b/file-bumper/docker-bake.hcl
@@ -1,0 +1,12 @@
+// Expected to be used with https://github.com/rcwbr/dockerfile-partials/blob/main/github-cache-bake.hcl
+// For example, docker buildx bake -f github-cache-bake.hcl -f cwd://docker-bake.hcl https://github.com/rcwbr/dockerfile-partials.git#0.1.0
+
+target "default" {
+  contexts = {
+    base = (
+      ("${GITHUB_REF_PROTECTED}" == "true" || "${GITHUB_REF_TYPE}" == "tag" )
+      ? "docker-image://${REGISTRY}release-it-docker-conventional-changelog:${VERSION}"
+      : "docker-image://${REGISTRY}release-it-docker-conventional-changelog:${VERSION}-${GITHUB_SHA}"
+    )
+  }
+}


### PR DESCRIPTION
Closes #46 

> ## What
> 
> Specify an image with capabilities to manage a version file in source
> 
> ## Why
> 
> Some use-cases require in-source updates to version files
> 
> ## How
> 
> Leverage the [bumper plugin](https://github.com/release-it/bumper)