### PR TITLE
Allow release-it push to default branch

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -41,6 +41,9 @@ rulesets:
       - actor_id: 5 # Based on https://registry.terraform.io/providers/integrations/github/latest/docs/resources/organization_ruleset#bypass_actors
         actor_type: RepositoryRole
         bypass_mode: pull_request
+      - actor_id: 1033419 # release-it-docker-ci-release-it App ID
+        actor_type: Integration
+        bypass_mode: always
     rules:
       - type: creation
       - type: deletion


### PR DESCRIPTION
Closes #48 

## What

Grant the release-it app actor id bypass permissions to push to `main` without a PR.

## Why

So that release-it can push a version bump commit on PR merge, avoiding errors like

```bash
✖ Git push
ERROR remote: error: GH013: Repository rule violations found for refs/heads/main.        
remote: Review all repository rules at https://github.com/rcwbr/release-it-docker/rules?ref=refs%2Fheads%2Fmain        
remote: 
remote: - Changes must be made through a pull request.        
remote: 
remote: - 2 of 2 required status checks are expected.        
remote: 
remote: Bypassed rule violations for refs/tags/0.6.0:        
remote: 
remote: - Cannot create ref due to create name restrictions.        
remote: 
To https://github.com/rcwbr/release-it-docker
 * [new tag]         0.6.0 -> 0.6.0
 ! [remote rejected] main -> main (push declined due to repository rule violations)
error: failed to push some refs to 'https://github.com/rcwbr/release-it-docker'
Rolling back changes...
Deleting local tag 0.6.0
Resetting local changes made
Error: Process completed with exit code 1.
```

## How

Adjust the `.github/settings.yml` file