### PR TITLE
Specify release commit message pattern in configuration

### DIFF
--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -63,7 +63,7 @@ jobs:
       docker-bake-conventional-changelog-metadata: ${{ steps.docker-bake-conventional-changelog.outputs.metadata }}
       docker-bake-file-bumper-metadata: ${{ steps.docker-bake-file-bumper.outputs.metadata }}
   release-it-workflow:
-    uses: rcwbr/release-it-gh-workflow/.github/workflows/release-it-workflow.yaml@0.1.0
+    uses: rcwbr/release-it-gh-workflow/.github/workflows/release-it-workflow.yaml@0.2.2
     needs: build-docker-images
     with:
       release-it-image: ${{ fromJSON(needs.build-docker-images.outputs.docker-bake-file-bumper-metadata)['default']['image.name'] }}

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ The recommended approach to apply this image in a GitHub workflow is via the reu
 
 ## Contributing
 
+### Release-it config file layering
+
+The `.release-it.json` configuration files in the image subdirectories are merged using [jq](https://jqlang.github.io/jq/), such that the content of each JSON file represents only the delta to that of the base image. This combination logic is expressed within each image's Dockerfile.
+
 ### Build
 
 The recommended method to build the image is using [Docker Bake](https://docs.docker.com/reference/cli/docker/buildx/bake/) and the [Dockerfile partials GitHub cache bake file](https://github.com/rcwbr/dockerfile-partials/tree/main?tab=readme-ov-file#github-cache-bake-file). The steps to build the image using this method are as follows.

--- a/base/.release-it.json
+++ b/base/.release-it.json
@@ -1,6 +1,7 @@
 {
   "git": {
-    "commit": false
+    "commit": false,
+    "commitMessage": "release: ${version}"
   },
   "github": {
     "release": true

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,5 +1,12 @@
 FROM node:22.9.0
 
+# Install JQ for use in combining config files
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt-get update \
+  && apt-get install --allow-unauthenticated --no-install-recommends -y \
+    jq \
+  && rm -rf /var/lib/apt/lists/*
+
 RUN npm install -g release-it
 
 COPY .release-it.json /.release-it.json

--- a/conventional-changelog/.release-it.json
+++ b/conventional-changelog/.release-it.json
@@ -1,11 +1,7 @@
 {
   "git": {
-    "commit": false,
     "tag": true,
     "tagName": "${version}"
-  },
-  "github": {
-    "release": true
   },
   "plugins": {
     "@release-it/conventional-changelog": {

--- a/conventional-changelog/Dockerfile
+++ b/conventional-changelog/Dockerfile
@@ -1,4 +1,11 @@
+FROM base AS config
+
+COPY .release-it.json /conventional-changelog-release-it.json
+# Combine the release-it config file from base with the local file
+RUN jq --slurp '.[0] * .[1]' /.release-it.json /conventional-changelog-release-it.json | tee /combined-release-it.json
+
+
 FROM base
 
 RUN npm install -g @release-it/conventional-changelog
-COPY .release-it.json /.release-it.json
+COPY --from=config /combined-release-it.json /.release-it.json

--- a/file-bumper/.release-it.json
+++ b/file-bumper/.release-it.json
@@ -1,11 +1,6 @@
 {
   "git": {
-    "commit": true,
-    "tag": true,
-    "tagName": "${version}"
-  },
-  "github": {
-    "release": true
+    "commit": true
   },
   "plugins": {
     "@release-it/bumper": {
@@ -23,53 +18,6 @@
           "type": "text/plain"
         }
       ]
-    },
-    "@release-it/conventional-changelog": {
-      "preset": {
-        "name": "conventionalcommits",
-        "types": [
-          {
-            "type": "feat",
-            "section": ":rocket: Features"
-          },
-          {
-            "type": "fix",
-            "section": ":bug: Bug fixes"
-          },
-          {
-            "type": "build",
-            "section": ":package: Build"
-          },
-          {
-            "type": "ci",
-            "section": ":robot: CI/CD"
-          },
-          {
-            "type": "docs",
-            "section": ":page_facing_up: Docs"
-          },
-          {
-            "type": "perf",
-            "section": ":checkered_flag: Performance"
-          },
-          {
-            "type": "refactor",
-            "section": ":twisted_rightwards_arrows: Refactor"
-          },
-          {
-            "type": "style",
-            "section": ":broom: Style"
-          },
-          {
-            "type": "test",
-            "section": ":test_tube: Tests"
-          },
-          {
-            "type": "chore",
-            "hidden": true
-          }
-        ]
-      }
     }
   }
 }

--- a/file-bumper/.tag-only-release-it.json
+++ b/file-bumper/.tag-only-release-it.json
@@ -1,13 +1,7 @@
 {
   "git": {
     "getLatestTagFromAllRefs": true,
-    "commit": true,
-    "tag": true,
-    "pushArgs": ["--tags"],
-    "tagName": "${version}"
-  },
-  "github": {
-    "release": true
+    "pushArgs": ["--tags"]
   },
   "plugins": {
     "@release-it/bumper": {
@@ -15,53 +9,6 @@
         "file": "VERSION",
         "type": "text/plain",
         "consumeWholeFile": true
-      }
-    },
-    "@release-it/conventional-changelog": {
-      "preset": {
-        "name": "conventionalcommits",
-        "types": [
-          {
-            "type": "feat",
-            "section": ":rocket: Features"
-          },
-          {
-            "type": "fix",
-            "section": ":bug: Bug fixes"
-          },
-          {
-            "type": "build",
-            "section": ":package: Build"
-          },
-          {
-            "type": "ci",
-            "section": ":robot: CI/CD"
-          },
-          {
-            "type": "docs",
-            "section": ":page_facing_up: Docs"
-          },
-          {
-            "type": "perf",
-            "section": ":checkered_flag: Performance"
-          },
-          {
-            "type": "refactor",
-            "section": ":twisted_rightwards_arrows: Refactor"
-          },
-          {
-            "type": "style",
-            "section": ":broom: Style"
-          },
-          {
-            "type": "test",
-            "section": ":test_tube: Tests"
-          },
-          {
-            "type": "chore",
-            "hidden": true
-          }
-        ]
       }
     }
   }

--- a/file-bumper/Dockerfile
+++ b/file-bumper/Dockerfile
@@ -1,5 +1,15 @@
+FROM base AS config
+
+COPY .release-it.json /file-bumper.json
+# Combine the release-it config file from base with the local file
+RUN jq --slurp '.[0] * .[1]' /.release-it.json /file-bumper.json | tee /combined-release-it.json
+COPY .tag-only-release-it.json /file-bumper-tag-only.json
+# Combine the previously-combined config file with the tag-only local file
+RUN jq --slurp '.[0] * .[1]' /combined-release-it.json /file-bumper-tag-only.json | tee /combined-release-it-tag-only.json
+
+
 FROM base
 
 RUN npm install -g @release-it/bumper
-COPY .release-it.json /.release-it.json
-COPY .tag-only-release-it.json /.tag-only-release-it.json
+COPY --from=config /combined-release-it.json /.release-it.json
+COPY --from=config /combined-release-it-tag-only.json /.tag-only-release-it.json


### PR DESCRIPTION
Closes #52 

> ## What
> 
> Specify a release commit message pattern in the release-it configuration files
> 
> ## Why
> 
> To standardize the commit messages used for releases, and enable functionality that relies on that standardization (e.g. [logic to prevent re-triggering workflows from release commits](https://github.com/rcwbr/release-it-gh-workflow/issues/15))
> 
> ## How
> 
> Specify `git.commitMessage` in the config files. Leverage JQ to assemble the files based on deltas