### PR TITLE
fix: conventional changelog working version

### DIFF
--- a/conventional-changelog/Dockerfile
+++ b/conventional-changelog/Dockerfile
@@ -1,3 +1,3 @@
 FROM base
 
-RUN npm install --global @release-it/conventional-changelog@10.0.2
+RUN npm install --global @release-it/conventional-changelog@9.0.4


### PR DESCRIPTION
Closes #56 

> ## What
> 
> Downgrade release-it/conventional-changelog.
> 
> ## Why
> 
> Config is handled improperly using conventional-changelog. See https://github.com/release-it/conventional-changelog/issues/128
> 
> ## How
> 
> Pin version to 9.0.4